### PR TITLE
NO-JIRA [Bug] lldb이슈가 수정된 flexLayout버전으로 교체

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,9 +13,13 @@ project 'Projects/DesignSystem.xcodeproj'
 project 'Projects/Core/Networking/Networking.xcodeproj'
 project 'Projects/Core/LoginManager/LoginManager.xcodeproj'
 
+def flex_layout
+  pod 'FlexLayout', :git => 'git@github.com:pink-boss/FlexLayout.git'
+end
+
 target 'Joosum' do
   project 'Projects/Joosum/Joosum.xcodeproj'
-  pod 'FlexLayout', '~> 1.0'
+  flex_layout
   pod 'PinLayout', '~> 1.0'
   pod 'GoogleSignIn'
 end
@@ -26,7 +30,7 @@ end
 
 target 'Presentation' do
   project 'Projects/Presentation/Presentation.xcodeproj'
-  pod 'FlexLayout', '~> 1.0'
+  flex_layout
   pod 'PinLayout', '~> 1.0'
   pod 'GoogleSignIn'
 end
@@ -38,7 +42,7 @@ end
 
 target 'DesignSystem' do
   project 'Projects/DesignSystem/DesignSystem.xcodeproj'
-  pod 'FlexLayout', '~> 1.0'
+  flex_layout
   pod 'PinLayout', '~> 1.0'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - AppAuth/Core (1.6.2)
   - AppAuth/ExternalUserAgent (1.6.2):
     - AppAuth/Core
-  - FlexLayout (1.3.31)
+  - FlexLayout (1.3.32)
   - GoogleSignIn (7.0.0):
     - AppAuth (~> 1.5)
     - GTMAppAuth (< 3.0, >= 1.3)
@@ -17,27 +17,35 @@ PODS:
   - PinLayout (1.10.3)
 
 DEPENDENCIES:
-  - FlexLayout (~> 1.0)
+  - "FlexLayout (from `git@github.com:pink-boss/FlexLayout.git`)"
   - GoogleSignIn
   - PinLayout (~> 1.0)
 
 SPEC REPOS:
   trunk:
     - AppAuth
-    - FlexLayout
     - GoogleSignIn
     - GTMAppAuth
     - GTMSessionFetcher
     - PinLayout
 
+EXTERNAL SOURCES:
+  FlexLayout:
+    :git: "git@github.com:pink-boss/FlexLayout.git"
+
+CHECKOUT OPTIONS:
+  FlexLayout:
+    :commit: e078c62e20094dfe25526831ac183704f7343bea
+    :git: "git@github.com:pink-boss/FlexLayout.git"
+
 SPEC CHECKSUMS:
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  FlexLayout: 8010187077ecf09710cdf0e9c8ffe2c9b92ec5db
+  FlexLayout: 9184986cace599a581164c8e4af8c860698837af
   GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
   GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
   PinLayout: 0090ccbf29ae69af6ae5a15eaeaf27ed7b2c4d83
 
-PODFILE CHECKSUM: fd409f7aab3d3815bc735dc4399ffd86b01713c2
+PODFILE CHECKSUM: 1554dcaae0db32ffdad4e3e9ae8432694cc552fc
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
## 배경

- LLDB에서 FlexLayout 를 import하는 과정에서 SPM 전처리문으로 분기되는 문제

## 수정내역

- FlexLayout을 pinkboss Organization으로 Fork 후 FlexLayout에서 문제되는 RP Merge를 Revert했어요 [Revert](https://github.com/pink-boss/FlexLayout/commit/e078c62e20094dfe25526831ac183704f7343bea)
- 저희는 CocoaPod을 사용하기 때문에 해당 Revert해도 문제없이 작동해요